### PR TITLE
The supabase npm package was mistyped

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ npm install
 - Install supabase Javascript client:
 
 ```bash
-$ npm install @supabase/supbase-js
+$ npm install @supabase/supabase-js
 ```
 - Create `.env` file for the Supabase `URL` and `ANON` key:
 ```


### PR DESCRIPTION
just a text change in the readme file for the the name on an npm package. 